### PR TITLE
Refactor: Run moqui_interpreter once per case

### DIFF
--- a/src/domain/states.py
+++ b/src/domain/states.py
@@ -127,53 +127,10 @@ class InitialState(WorkflowState):
             "tps_file": str(tps_file)
         })
 
-        return PreprocessingState()
-
-    def get_state_name(self) -> str:
-        return "Initial Validation"
-
-
-class PreprocessingState(WorkflowState):
-    """
-    Preprocessing state - runs mqi_interpreter locally for a single beam.
-    """
-
-    @handle_state_exceptions
-    def execute(self, context: 'WorkflowManager') -> WorkflowState:
-        """
-        Execute local preprocessing using mqi_interpreter for the given beam.
-        """
-        context.logger.info("Running mqi_interpreter preprocessing for beam", {
-            "beam_id": context.id
-        })
-        
-        beam_path = context.path
-        input_file = beam_path / "moqui_tps.in"
-        if not input_file.exists():
-            raise ProcessingError(f"moqui_tps.in file not found in beam directory: {input_file}")
-
-        result = context.local_handler.run_mqi_interpreter(
-            beam_directory=beam_path,
-            output_dir=beam_path
-        )
-
-        if not result.success:
-            raise ProcessingError(f"mqi_interpreter failed for beam '{context.id}'. Error: {result.error}")
-
-        csv_files = list(beam_path.glob("*.csv"))
-        if not csv_files:
-            raise ProcessingError("No CSV files generated after preprocessing beam")
-            
-        context.logger.info("Preprocessing completed successfully for beam", {
-            "beam_id": context.id,
-            "beam_path": str(beam_path),
-            "csv_files_count": len(csv_files)
-        })
-
         return FileUploadState()
 
     def get_state_name(self) -> str:
-        return "Preprocessing"
+        return "Initial Validation"
 
 class FileUploadState(WorkflowState):
     """

--- a/src/handlers/local_handler.py
+++ b/src/handlers/local_handler.py
@@ -294,15 +294,16 @@ class LocalHandler:
             return False
 
     def run_mqi_interpreter(
-        self, beam_directory: Path, output_dir: Path
+        self, beam_directory: Path, output_dir: Path, case_id: Optional[str] = None
     ) -> ExecutionResult:
         """
         mqi_interpreter 실행을 위한 Wrapper 메서드.
         템플릿에 필요한 동적 인자를 정의하고, 명령어 생성을 위임합니다.
 
         Args:
-            beam_directory: Path to the beam directory (used as --logdir).
+            beam_directory: Path to the beam directory (or case directory).
             output_dir: Path to the output directory for generated files.
+            case_id: Optional case_id. If not provided, it's inferred from the parent directory.
 
         Returns:
             ExecutionResult containing execution details.
@@ -317,9 +318,12 @@ class LocalHandler:
             "mqi_interpreter", **dynamic_args
         )
         
-        case_id = beam_directory.parent.name
+        # If case_id is not provided, infer it from the parent directory (for beam-level calls)
+        # Otherwise, use the provided case_id (for case-level calls)
+        id_to_use = case_id if case_id is not None else beam_directory.parent.name
+
         # execute_mqi_interpreter는 이제 미리 빌드된 명령어를 받아 실행만 담당
-        return self.execute_mqi_interpreter(case_id, beam_directory, command_to_execute)
+        return self.execute_mqi_interpreter(id_to_use, beam_directory, command_to_execute)
 
     def run_raw_to_dcm(
         self, input_file: Path, output_dir: Path, case_path: Path


### PR DESCRIPTION
This refactoring changes the workflow to run the `moqui_interpreter` process once for the entire case, rather than for each individual beam. This is a more efficient approach as the interpreter can handle the entire case in a single run.

Changes:
- A new function `run_case_level_preprocessing` is added to `src/core/dispatcher.py` to handle the case-level execution of `moqui_interpreter`.
- The main application loop in `main.py` is modified to call this new function before dispatching individual beam workers.
- The `PreprocessingState` has been removed from the beam-level state machine in `src/domain/states.py`, and the workflow now transitions from `InitialState` directly to `FileUploadState`.
- The `run_mqi_interpreter` method in `src/handlers/local_handler.py` was updated to support being called with a case-level ID.
- Tests for `PreprocessingState` were removed, and the `InitialState` test was updated to reflect the new workflow.